### PR TITLE
implement DeleteSale use case with handler and tests

### DIFF
--- a/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.DeleteSale
+{
+    /// <summary>
+    /// Command for deleting (cancelling) a sale by its ID.
+    /// </summary>
+    public record DeleteSaleCommand(Guid Id) : IRequest<DeleteSaleResponse>;
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleHandler.cs
@@ -1,0 +1,36 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Repositories;
+using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.DeleteSale
+{
+    /// <summary>
+    /// Handles the cancellation of a sale.
+    /// </summary>
+    public class DeleteSaleHandler : IRequestHandler<DeleteSaleCommand, DeleteSaleResponse>
+    {
+        private readonly ISaleRepository _saleRepository;
+
+        public DeleteSaleHandler(ISaleRepository saleRepository)
+        {
+            _saleRepository = saleRepository;
+        }
+
+        public async Task<DeleteSaleResponse> Handle(DeleteSaleCommand request, CancellationToken cancellationToken)
+        {
+            var sale = await _saleRepository.GetByIdAsync(request.Id, cancellationToken);
+
+            if (sale == null)
+                throw new KeyNotFoundException($"Sale with ID {request.Id} not found.");
+
+            sale.Cancel();
+
+            await _saleRepository.UpdateAsync(sale, cancellationToken);
+
+            return new DeleteSaleResponse
+            {
+                Id = sale.Id,
+                Cancelled = sale.Cancelled
+            };
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace Ambev.DeveloperEvaluation.Application.Sales.DeleteSale
+{
+    /// <summary>
+    /// Response returned after successfully cancelling a sale.
+    /// </summary>
+    public class DeleteSaleResponse
+    {
+        public Guid Id { get; set; }
+        public bool Cancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
@@ -1,27 +1,31 @@
 ﻿using Ambev.DeveloperEvaluation.Domain.Entities;
 
-namespace Ambev.DeveloperEvaluation.Domain.Repositories
+namespace Ambev.DeveloperEvaluation.Domain.Repositories;
+
+/// <summary>
+/// Contract for sale persistence and retrieval operations.
+/// Implements the repository pattern for the Sale aggregate.
+/// </summary>
+public interface ISaleRepository
 {
+    /// <summary>
+    /// Adds a new sale to the repository.
+    /// </summary>
+    Task AddAsync(Sale sale, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Contract for sale persistence and retrieval operations.
-    /// Implements the repository pattern for the Sale aggregate.
+    /// Gets a sale by its unique identifier.
     /// </summary>
-    public interface ISaleRepository
-    {
-        /// <summary>
-        /// Adds a new sale to the repository.
-        /// </summary>
-        Task AddAsync(Sale sale, CancellationToken cancellationToken = default);
+    Task<Sale?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Gets a sale by its unique identifier.
-        /// </summary>
-        Task<Sale?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Lists all sales in the system.
+    /// </summary>
+    Task<List<Sale>> ListAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Lists all sales in the system.
-        /// </summary>
-        Task<List<Sale>> ListAsync(CancellationToken cancellationToken = default);
-    }
+    /// <summary>
+    /// Updates an existing sale in the repository.
+    /// Used for operations such as cancelling a sale.
+    /// </summary>
+    Task UpdateAsync(Sale sale, CancellationToken cancellationToken = default);
 }

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSale/DeleteSaleHandlerTestData.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSale/DeleteSaleHandlerTestData.cs
@@ -1,0 +1,36 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Bogus;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales.DeleteSale
+{
+    /// <summary>
+    /// Provides fake Sale entities for DeleteSaleHandler unit tests.
+    /// </summary>
+    public static class DeleteSaleHandlerTestData
+    {
+        private static readonly Faker faker = new();
+
+        /// <summary>
+        /// Generates a valid sale with one or more items.
+        /// </summary>
+        public static Sale GenerateValidSale()
+        {
+            var sale = new Sale(
+                customerExternalId: faker.Random.Guid().ToString(),
+                branchExternalId: faker.Random.Guid().ToString()
+            );
+
+            int itemCount = faker.Random.Int(1, 3);
+            for (int i = 0; i < itemCount; i++)
+            {
+                sale.AddItem(
+                    productExternalId: faker.Commerce.Ean13(),
+                    quantity: faker.Random.Int(1, 10),
+                    unitPrice: faker.Random.Decimal(10, 200)
+                );
+            }
+
+            return sale;
+        }
+    }
+}

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSale/DeleteSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSale/DeleteSaleHandlerTests.cs
@@ -1,0 +1,61 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.DeleteSale;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using Moq;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales.DeleteSale
+{
+    public class DeleteSaleHandlerTests
+    {
+        private readonly Mock<ISaleRepository> _saleRepositoryMock;
+        private readonly DeleteSaleHandler _handler;
+
+        public DeleteSaleHandlerTests()
+        {
+            _saleRepositoryMock = new Mock<ISaleRepository>();
+            _handler = new DeleteSaleHandler(_saleRepositoryMock.Object);
+        }
+
+        [Fact(DisplayName = "Should cancel sale and return confirmation")]
+        public async Task Handle_ValidSale_ShouldCancelAndReturn()
+        {
+            // Arrange
+            var sale = new Sale("CUST-001", "BRANCH-001");
+            _saleRepositoryMock
+                .Setup(repo => repo.GetByIdAsync(sale.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sale);
+
+            var command = new DeleteSaleCommand(sale.Id);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Cancelled);
+            Assert.Equal(sale.Id, result.Id);
+
+            _saleRepositoryMock.Verify(r => r.GetByIdAsync(sale.Id, It.IsAny<CancellationToken>()), Times.Once);
+            _saleRepositoryMock.Verify(r => r.UpdateAsync(sale, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "Should throw KeyNotFoundException when sale does not exist")]
+        public async Task Handle_NonExistingSale_ShouldThrowException()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+
+            _saleRepositoryMock
+                .Setup(repo => repo.GetByIdAsync(saleId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Sale?)null);
+
+            var command = new DeleteSaleCommand(saleId);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() =>
+                _handler.Handle(command, CancellationToken.None));
+
+            _saleRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Sale>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
Implemented the DeleteSale use case, allowing sale cancellation via handler and MediatR command. Added repository update method, response model, and unit tests with data generation using Bogus. Covers scenarios for valid cancellation and not found exception.