### PR TITLE
implement infrastructure and IoC for Sale entity with working Swagger

### DIFF
--- a/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
+++ b/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
@@ -3,7 +3,6 @@ using Ambev.DeveloperEvaluation.ORM;
 using Ambev.DeveloperEvaluation.ORM.Repositories;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Ambev.DeveloperEvaluation.IoC.ModuleInitializers;
@@ -14,5 +13,6 @@ public class InfrastructureModuleInitializer : IModuleInitializer
     {
         builder.Services.AddScoped<DbContext>(provider => provider.GetRequiredService<DefaultContext>());
         builder.Services.AddScoped<IUserRepository, UserRepository>();
+        builder.Services.AddScoped<ISaleRepository, SaleRepository>();
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
@@ -4,39 +4,51 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 using System.Reflection;
 
-namespace Ambev.DeveloperEvaluation.ORM;
-
-public class DefaultContext : DbContext
+namespace Ambev.DeveloperEvaluation.ORM
 {
-    public DbSet<User> Users { get; set; }
 
-    public DefaultContext(DbContextOptions<DefaultContext> options) : base(options)
+    /// <summary>
+    /// Main DbContext for the application. Handles entity sets and mapping.
+    /// </summary>
+    public class DefaultContext : DbContext
     {
+        public DbSet<User> Users { get; set; }
+        public DbSet<Sale> Sales { get; set; }
+        public DbSet<SaleItem> SaleItems { get; set; }
+
+        public DefaultContext(DbContextOptions<DefaultContext> options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Applies all IEntityTypeConfiguration mappings in this assembly
+            modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+            base.OnModelCreating(modelBuilder);
+        }
     }
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    /// <summary>
+    /// Design-time factory for generating migrations and other tooling.
+    /// </summary>
+    public class DefaultContextFactory : IDesignTimeDbContextFactory<DefaultContext>
     {
-        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
-        base.OnModelCreating(modelBuilder);
-    }
-}
-public class YourDbContextFactory : IDesignTimeDbContextFactory<DefaultContext>
-{
-    public DefaultContext CreateDbContext(string[] args)
-    {
-        IConfigurationRoot configuration = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json")
-            .Build();
+        public DefaultContext CreateDbContext(string[] args)
+        {
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json")
+                .Build();
 
-        var builder = new DbContextOptionsBuilder<DefaultContext>();
-        var connectionString = configuration.GetConnectionString("DefaultConnection");
+            var builder = new DbContextOptionsBuilder<DefaultContext>();
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
 
-        builder.UseNpgsql(
-               connectionString,
-               b => b.MigrationsAssembly("Ambev.DeveloperEvaluation.WebApi")
-        );
+            builder.UseNpgsql(
+                connectionString,
+                b => b.MigrationsAssembly("Ambev.DeveloperEvaluation.WebApi")
+            );
 
-        return new DefaultContext(builder.Options);
+            return new DefaultContext(builder.Options);
+        }
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
@@ -1,0 +1,50 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ambev.DeveloperEvaluation.ORM.Mapping
+{
+    /// <summary>
+    /// Configuration for the Sale entity using Fluent API.
+    /// Defines table name, keys, properties, and relationships.
+    /// </summary>
+    public class SaleConfiguration : IEntityTypeConfiguration<Sale>
+    {
+        public void Configure(EntityTypeBuilder<Sale> builder)
+        {
+            builder.ToTable("Sales");
+
+            // Primary key
+            builder.HasKey(s => s.Id);
+
+            // ID with UUID type and default generation
+            builder.Property(s => s.Id)
+                .HasColumnType("uuid")
+                .HasDefaultValueSql("gen_random_uuid()");
+
+            // Customer external identifier
+            builder.Property(s => s.CustomerExternalId)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            // Branch external identifier
+            builder.Property(s => s.BranchExternalId)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            // Sale date
+            builder.Property(s => s.SaleDate)
+                .IsRequired();
+
+            // Cancellation flag
+            builder.Property(s => s.Cancelled)
+                .IsRequired();
+
+            // One-to-many relationship: Sale → SaleItem
+            builder.HasMany(s => s.Items)
+                   .WithOne()
+                   .HasForeignKey("SaleId") // Shadow property
+                   .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
@@ -1,0 +1,43 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ambev.DeveloperEvaluation.ORM.Mapping
+{
+
+    /// <summary>
+    /// Configuration for the SaleItem entity using Fluent API
+    /// </summary>
+    public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
+    {
+        public void Configure(EntityTypeBuilder<SaleItem> builder)
+        {
+            builder.ToTable("SaleItems");
+
+            builder.HasKey(i => i.Id);
+
+            builder.Property(i => i.Id)
+                .HasColumnType("uuid")
+                .HasDefaultValueSql("gen_random_uuid()");
+
+            builder.Property(i => i.ProductExternalId)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            builder.Property(i => i.Quantity)
+                .IsRequired();
+
+            builder.Property(i => i.UnitPrice)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(i => i.Discount)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            // Foreign key to Sale (shadow property "SaleId")
+            builder.Property<Guid>("SaleId")
+                .IsRequired();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
@@ -1,0 +1,69 @@
+﻿using Ambev.DeveloperEvaluation.Common.Pagination;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ambev.DeveloperEvaluation.ORM.Repositories
+{
+    /// <summary>
+    /// Implementation of ISaleRepository using Entity Framework Core
+    /// </summary>
+    public class SaleRepository : ISaleRepository
+    {
+        private readonly DefaultContext _context;
+
+        /// <summary>
+        /// Initializes a new instance of SaleRepository
+        /// </summary>
+        /// <param name="context">The database context</param>
+        public SaleRepository(DefaultContext context)
+        {
+            _context = context;
+        }
+
+        /// <inheritdoc />
+        public async Task AddAsync(Sale sale, CancellationToken cancellationToken = default)
+        {
+            await _context.Sales.AddAsync(sale, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<Sale?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return await _context.Sales
+                .Include(s => s.Items)
+                .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<Sale>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.Sales
+                .Include(s => s.Items)
+                .OrderByDescending(s => s.SaleDate)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task UpdateAsync(Sale sale, CancellationToken cancellationToken = default)
+        {
+            _context.Sales.Update(sale);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<PaginatedList<Sale>> GetPagedAsync(int page, int pageSize, CancellationToken cancellationToken = default)
+        {
+            var query = _context.Sales.Include(s => s.Items).OrderByDescending(s => s.SaleDate);
+            var totalItems = await query.CountAsync(cancellationToken);
+
+            var items = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PaginatedList<Sale>(items, totalItems, page, pageSize);
+        }
+    }
+}


### PR DESCRIPTION
- Implemented `SaleRepository` with full support for Add, GetById, Update, List, and Paged queries.
- Added `Sale` and `SaleItem` mappings using Fluent API (`SaleConfiguration` and `SaleItemConfiguration`).
- Updated `DefaultContext` with `DbSet<Sale>` and `DbSet<SaleItem>`.
- Renamed the factory class to `DefaultContextFactory` for clarity and professionalism.