### PR TITLE
implement cancel sale command and handler with domain validation

### DIFF
--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SaleController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SaleController.cs
@@ -1,4 +1,5 @@
 ﻿using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
+using Ambev.DeveloperEvaluation.Application.Sales.DeleteSale;
 using Ambev.DeveloperEvaluation.Application.Sales.GetSale;
 using Ambev.DeveloperEvaluation.Application.Sales.Query.ListPagedSale;
 using Ambev.DeveloperEvaluation.Common.Pagination;
@@ -70,6 +71,22 @@ public class SaleController : BaseController
         try
         {
             var result = await _mediator.Send(new GetSaleCommand(id), cancellationToken);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(typeof(DeleteSaleResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Cancel(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _mediator.Send(new DeleteSaleCommand(id), cancellationToken);
             return Ok(result);
         }
         catch (KeyNotFoundException)


### PR DESCRIPTION
- Implemented DeleteSaleCommand and DeleteSaleHandler to support soft cancellation of a sale.
- Applied domain logic using the Sale.Cancel() method, including business rule validation.
- Added DeleteSaleResponse to return cancellation status.
- Registered route DELETE /api/Sale/{id} in SaleController.
- Included NotFound handling when sale is not found.
- Controller returns 200 OK with cancellation confirmation.

This completes the functional requirements for sale cancellation as per the evaluation spec.